### PR TITLE
Always write debug to a file instead of stdout

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -32,3 +32,6 @@
 - Contradicting flags are not allowed in zypper-migration plugin to match new
   zypper behavior (see e.g.: https://github.com/openSUSE/zypper/pull/215 for
   more details).
+- Zypper backup doesn't use parallel gzip but tar's built in gzip functionality
+  which doesn't require shell pipes.
+- Zypper backup stores both tarball and restore script under `--root` path.

--- a/internal/connect/zypper-restore.tmpl
+++ b/internal/connect/zypper-restore.tmpl
@@ -1,0 +1,11 @@
+#! /bin/sh
+# change root to first parameter or use / as default
+# it is needed to allow restore in installation
+cd ${1:-/}
+{{- range .Paths }}
+rm -rf {{ . -}}
+{{ end }}
+
+tar xvf {{ .Tarball }} --overwrite
+# return back to original dir
+cd -

--- a/internal/connect/zypper.go
+++ b/internal/connect/zypper.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	_ "embed" //golint
 	"encoding/xml"
 	"strings"
 )
@@ -30,6 +31,11 @@ const (
 	zypperInfoCapNotFound     = 104 // install or remove command encountered arguments matching no of the available package names or capabilities
 	zypperInfoOnSignal        = 105 // Returned upon exiting after receiving a SIGINT or SIGTERM
 	zypperInfoReposSkipped    = 106 // Some repository had to be disabled temporarily because it failed to refresh
+)
+
+var (
+	//go:embed zypper-restore.tmpl
+	restoreTemplate string
 )
 
 func zypperRun(args []string, validExitCodes []int) ([]byte, error) {

--- a/internal/connect/zypperbackup.go
+++ b/internal/connect/zypperbackup.go
@@ -1,0 +1,118 @@
+package connect
+
+import (
+	_ "embed" //golint
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"text/template"
+)
+
+func createZypperTarball(tarballPath, root string, paths []string) error {
+	// tar reports an error if a file does not exist.
+	// So we have to check this before.
+	var existingPaths []string
+	for _, p := range paths {
+		if !fileExists(p) {
+			continue
+		}
+		// remove leading "/" from paths to allow using them from different root
+		existingPaths = append(existingPaths, strings.TrimLeft(p, "/"))
+	}
+
+	// make tarball path relative to root
+	tarballPath = strings.TrimLeft(tarballPath, "/")
+	tarballPathWithRoot := path.Join(root, tarballPath)
+
+	// ensure directory exists
+	if err := os.MkdirAll(path.Dir(tarballPathWithRoot), os.ModeDir); err != nil {
+		return err
+	}
+
+	// using -f tarballPathWithRoot here instead of -f tarballPath because
+	// tar doesn't seem to use -C root for output files
+	command := []string{"tar", "cz", "-C", root, "-f", tarballPathWithRoot}
+	command = append(command, existingPaths...)
+	_, err := execute(command, []int{0})
+
+	// tarball can contain sensitive data, so prevent read to non-root
+	// do it for sure even if tar failed as it can contain partial content
+	if fileExists(tarballPathWithRoot) {
+		os.Chmod(tarballPathWithRoot, 0600)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to create backup: %v", err)
+	}
+	return nil
+}
+
+func createZypperRestoreScript(scriptPath, tarballPath, root string, paths []string) error {
+	var data struct {
+		Paths   []string
+		Tarball string
+	}
+	// remove leading "/" from paths to allow using them from different root
+	for _, p := range paths {
+		data.Paths = append(data.Paths, strings.TrimLeft(p, "/"))
+	}
+	data.Tarball = strings.TrimLeft(tarballPath, "/")
+
+	// make script path relative to root
+	scriptPath = strings.TrimLeft(scriptPath, "/")
+	scriptPathWithRoot := path.Join(root, scriptPath)
+
+	t, err := template.New("restore-script").Parse(restoreTemplate)
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(scriptPathWithRoot)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	err = t.Execute(f, data)
+	if err != nil {
+		return err
+	}
+	// allow execution of script
+	os.Chmod(scriptPathWithRoot, 0744)
+	return nil
+}
+
+// ZypperBackup creates backup of zypper configuration files
+func ZypperBackup() error {
+	root := CFG.FsRoot
+	if root == "" {
+		root = "/"
+	}
+	paths := []string{
+		"/etc/zypp/repos.d",
+		"/etc/zypp/credentials.d",
+		"/etc/zypp/services.d",
+	}
+	tarballPath := "/var/adm/backup/system-upgrade/repos.tar.gz"
+	if err := createZypperTarball(tarballPath, root, paths); err != nil {
+		return err
+	}
+
+	scriptPath := "/var/adm/backup/system-upgrade/repos.sh"
+	if err := createZypperRestoreScript(scriptPath, tarballPath, root, paths); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ZypperRestore restores zypper configuration from backup created by ZypperBackup
+func ZypperRestore() error {
+	root := CFG.FsRoot
+	if root == "" {
+		root = "/"
+	}
+	_, err := execute([]string{"sh",
+		path.Join(root, "var/adm/backup/system-upgrade/repos.sh"),
+		root}, []int{0})
+	return err
+}

--- a/suseconnect/migration.go
+++ b/suseconnect/migration.go
@@ -1,7 +1,6 @@
 package main
 
 // TODO LIST
-// * zypp_backup/zypp_restore functions
 // * --selfupdate option
 // * offline migrations
 // * obsolete repo disabling (including --disable-repos option)
@@ -379,9 +378,12 @@ func migrationMain() {
 	if err != nil {
 		QuietOut.Print("\nPerforming repository rollback...\n")
 
-		// TODO
 		// restore repo configuration from backup file
-		//     zypp_restore
+		if err := connect.ZypperRestore(); err != nil {
+			// NOTE: original ignores failures of this command
+			fmt.Printf("Zypper restore failed: %v\n", err)
+		}
+
 		if err := connect.Rollback(); err == nil {
 			QuietOut.Println("Rollback successful.")
 		} else {
@@ -554,8 +556,11 @@ func migrateSystem(migration connect.MigrationPath) (string, error) {
 // returns fs_inconsistent flag
 func applyMigration(migration connect.MigrationPath, quiet, verbose, nonInteractive bool, dupArgs []string) (bool, error) {
 	fsInconsistent := false
-	// TODO
-	//   zypp_backup(options[:root] ? options[:root]: "/")
+
+	if err := connect.ZypperBackup(); err != nil {
+		// NOTE: original ignores failures of this command
+		fmt.Printf("Zypper backup failed: %v\n", err)
+	}
 
 	if interrupted {
 		return fsInconsistent, fmt.Errorf("Preparing migration: %v", ErrInterrupted)

--- a/suseconnect/migration.go
+++ b/suseconnect/migration.go
@@ -57,7 +57,6 @@ func migrationMain() {
 	var (
 		// dummy flag to keep default but accept cli arg
 		dummy          bool
-		debug          bool
 		verbose        bool
 		quiet          bool
 		nonInteractive bool
@@ -76,7 +75,6 @@ func migrationMain() {
 	flag.Usage = func() {
 		fmt.Print(migrationUsageText)
 	}
-	flag.BoolVar(&debug, "debug", false, "")
 	flag.BoolVar(&dummy, "no-verbose", false, "")
 	flag.BoolVar(&verbose, "verbose", false, "")
 	flag.BoolVar(&verbose, "v", false, "")
@@ -120,12 +118,18 @@ func migrationMain() {
 	// negations/negatives below
 	selfUpdate := !noSelfUpdate
 
+	logFile, err := os.OpenFile("/var/log/zypper-migrate.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		fmt.Printf("Unable to open log file: %v", err)
+	} else {
+		Debug.SetOutput(logFile)
+		Debug.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+		defer logFile.Close()
+	}
+	Debug.Printf("Started: %s\n", os.Args)
+
 	if verbose {
 		VerboseOut.SetOutput(os.Stdout)
-	}
-
-	if debug {
-		connect.EnableDebug()
 	}
 
 	if !quiet {


### PR DESCRIPTION
Stdout is already very verbose with zypper output from updating
hundreds of packages. Adding debug to stdout results in several
thousand lines which can overrun the terminal scrollback buffer.

The debug log will be invaluable for troubleshooting failures,
as all the zypper and api calls have their parameters and
outputs logged.